### PR TITLE
Fixed return type for task.status and routine

### DIFF
--- a/backend/src/tasks/controller.py
+++ b/backend/src/tasks/controller.py
@@ -1,6 +1,7 @@
 from typing import List
 from fastapi import APIRouter, Depends, HTTPException
 from common.exceptions import NotFoundException
+from tasks.enums import TaskStatus
 from tasks.service import TasksService
 from common.query_parameters import QueryParameters
 from tasks.models import TaskRead, TaskUpdate, TaskCreate, Task, TaskReadWithServiceAndPipeline
@@ -39,7 +40,7 @@ def get_one(
         400: {"detail": "Bad Request"},
         500: {"detail": "Internal Server Error"},
     },
-    response_model=TaskReadWithServiceAndPipeline,
+    response_model=TaskStatus,
 )
 async def get_one_status(
         task_id: UUID,
@@ -53,7 +54,7 @@ async def get_one_status(
         if task.status == "pending":
             task = await tasks_service.get_status_from_service(task)
 
-    return task
+    return task.status
 
 
 @router.get(

--- a/backend/src/tasks/service.py
+++ b/backend/src/tasks/service.py
@@ -174,14 +174,16 @@ class TasksService:
         """
         self.logger.debug("Get task status from service")
         status = await self.http_client.get(f"{task.service.url}/tasks/{task.id}/status")
-        self.logger.debug(f"Got status {status} from service {task.service.url}")
-        task.status = status
+        status = json.loads(status.content.decode("utf-8"))
+
+        task.status = status["status"]
+        self.logger.debug(f"Got status {task.status} from service {task.service.url}")
 
         self.session.add(task)
         self.session.commit()
         self.session.refresh(task)
 
-        return task
+        return task.status
 
     async def update(self, task_id: UUID, task: TaskUpdate):
         """


### PR DESCRIPTION
Check if the return type should still be a Task object or juste the Status of it.
The routine is fixed but the return type can be changed if needed.